### PR TITLE
fix key_tensor to use all 4 random bytes

### DIFF
--- a/torchcsprng/csrc/block_cipher.h
+++ b/torchcsprng/csrc/block_cipher.h
@@ -26,14 +26,20 @@ namespace csprng {
 // using `generator`, which must be an instance of `at::CPUGeneratorImpl`
 // and passes it to the `device`.
 template<typename RNG>
-at::Tensor key_tensor(c10::optional<at::Generator> generator, size_t block_t_size, at::Device device) {
+at::Tensor key_tensor(size_t block_t_size, c10::optional<at::Generator> generator) {
   std::lock_guard<std::mutex> lock(generator->mutex());
   auto gen = at::check_generator<RNG>(generator);
   auto t = torch::empty({static_cast<signed long>(block_t_size)}, torch::kUInt8);
-  for (size_t i = 0; i < block_t_size; i++) {
-    t[i] = static_cast<uint8_t>(gen->random());
+  using random_t = uint32_t;
+  constexpr size_t random_t_size = sizeof(random_t);
+  for (size_t i = 0; i < block_t_size / random_t_size; i++) {
+    const auto rand = gen->random();
+    for (size_t j = 0; j < random_t_size; j++) {
+      size_t k = i * random_t_size + j;
+      t[k] = static_cast<uint8_t>((rand >> (j * 8)) & 0xff);
+    }
   }
-  return t.to(device);
+  return t;
 }
 
 // A simple container for random state sub-blocks that implements RNG interface 

--- a/torchcsprng/csrc/csprng.h
+++ b/torchcsprng/csrc/csprng.h
@@ -92,7 +92,7 @@ template <> struct UIntType<bool> { using type = uint32_t; };
 template<typename RNG>
 struct RandomKernel {
   void operator()(TensorIterator& iter, c10::optional<Generator> generator) {
-    const Tensor key_t = key_tensor<RNG>(generator, aes::block_t_size, iter.device());
+    const Tensor key_t = key_tensor<RNG>(aes::block_t_size, generator).to(iter.device());
     const auto key = key_t.data_ptr<uint8_t>();
     AT_DISPATCH_ALL_TYPES_AND(ScalarType::Bool, iter.dtype(), "random_kernel", [&] {
       aes_helper<scalar_t, UIntType<scalar_t>::type>(iter, key,
@@ -128,7 +128,7 @@ void random_full_range_kernel_helper(TensorIterator& iter, const uint8_t* key) {
 template<typename RNG>
 struct RandomFromToKernel {
   void operator()(TensorIterator& iter, uint64_t range, int64_t base, c10::optional<Generator> generator) {
-    const Tensor key_t = key_tensor<RNG>(generator, aes::block_t_size, iter.device());
+    const Tensor key_t = key_tensor<RNG>(aes::block_t_size, generator).to(iter.device());
     const auto key = key_t.data_ptr<uint8_t>();
     AT_DISPATCH_ALL_TYPES_AND3(at::ScalarType::Bool, at::ScalarType::Half, at::ScalarType::BFloat16, iter.dtype(), "random_from_to_kernel", [&] {
       if ((
@@ -144,7 +144,7 @@ struct RandomFromToKernel {
     });
   }
   void operator()(TensorIterator& iter, c10::optional<Generator> generator) {
-    const Tensor key_t = key_tensor<RNG>(generator, aes::block_t_size, iter.device());
+    const Tensor key_t = key_tensor<RNG>(aes::block_t_size, generator).to(iter.device());
     const auto key = key_t.data_ptr<uint8_t>();
     AT_DISPATCH_ALL_TYPES_AND(at::ScalarType::BFloat16, iter.dtype(), "random_full_64_bits_range_kernel", [&] {
       if (std::is_same<scalar_t, int64_t>::value ||
@@ -177,7 +177,7 @@ Tensor& random_to(Tensor& self, int64_t to, c10::optional<Generator> generator) 
 template<typename RNG>
 struct UniformKernel {
   void operator()(TensorIterator& iter, double from, double to, c10::optional<Generator> generator) {
-    const Tensor key_t = key_tensor<RNG>(generator, aes::block_t_size, iter.device());
+    const Tensor key_t = key_tensor<RNG>(aes::block_t_size, generator).to(iter.device());
     const auto key = key_t.data_ptr<uint8_t>();
     AT_DISPATCH_FLOATING_TYPES(iter.dtype(), "uniform_kernel", [&] {
       aes_helper<scalar_t, uint64_t>(iter, key,
@@ -200,7 +200,7 @@ template<typename RNG>
 struct NormalKernel {
   void operator()(Tensor& self, double mean, double std, c10::optional<Generator> generator) {
     auto iter = TensorIterator::nullary_op(self);
-    const Tensor key_t = key_tensor<RNG>(generator, aes::block_t_size, iter.device());
+    const Tensor key_t = key_tensor<RNG>(aes::block_t_size, generator).to(iter.device());
     const auto key = key_t.data_ptr<uint8_t>();
     AT_DISPATCH_FLOATING_TYPES(iter.dtype(), "normal_kernel", [&] {
       aes_helper<scalar_t, uint64_t, 2>(iter, key,
@@ -246,7 +246,7 @@ Tensor normal_Tensor_Tensor(const Tensor& mean, const Tensor& std, c10::optional
 template<typename RNG>
 struct CauchyKernel {
   void operator()(TensorIterator& iter, double median, double sigma, c10::optional<Generator> generator) {
-    const Tensor key_t = key_tensor<RNG>(generator, aes::block_t_size, iter.device());
+    const Tensor key_t = key_tensor<RNG>(aes::block_t_size, generator).to(iter.device());
     const auto key = key_t.data_ptr<uint8_t>();
     AT_DISPATCH_FLOATING_TYPES(iter.dtype(), "cauchy_kernel", [&] {
       aes_helper<scalar_t, uint64_t, 1>(iter, key,
@@ -268,7 +268,7 @@ Tensor& cauchy_(Tensor& self, double median, double sigma, c10::optional<Generat
 template<typename RNG>
 struct LogNormalKernel {
   void operator()(TensorIterator& iter, double mean, double std, c10::optional<Generator> generator) {
-    const Tensor key_t = key_tensor<RNG>(generator, aes::block_t_size, iter.device());
+    const Tensor key_t = key_tensor<RNG>(aes::block_t_size, generator).to(iter.device());
     const auto key = key_t.data_ptr<uint8_t>();
     AT_DISPATCH_FLOATING_TYPES(iter.dtype(), "log_normal", [&] {
       aes_helper<scalar_t, uint64_t, 2>(iter, key,
@@ -290,7 +290,7 @@ Tensor& log_normal_(Tensor& self, double mean, double std, c10::optional<Generat
 template<typename RNG>
 struct GeometricKernel {
   void operator()(TensorIterator& iter, double p, c10::optional<Generator> generator) {
-    const Tensor key_t = key_tensor<RNG>(generator, aes::block_t_size, iter.device());
+    const Tensor key_t = key_tensor<RNG>(aes::block_t_size, generator).to(iter.device());
     const auto key = key_t.data_ptr<uint8_t>();
     AT_DISPATCH_FLOATING_TYPES(iter.dtype(), "geometric_kernel", [&] {
       aes_helper<scalar_t, UIntType<scalar_t>::type, 1>(iter, key,
@@ -312,7 +312,7 @@ Tensor& geometric_(Tensor& self, double p, c10::optional<Generator> gen) {
 template<typename RNG>
 struct ExponentialKernel {
   void operator()(TensorIterator& iter, double lambda, c10::optional<Generator> generator) {
-    const Tensor key_t = key_tensor<RNG>(generator, aes::block_t_size, iter.device());
+    const Tensor key_t = key_tensor<RNG>(aes::block_t_size, generator).to(iter.device());
     const auto key = key_t.data_ptr<uint8_t>();
     AT_DISPATCH_FLOATING_TYPES(iter.dtype(), "exponential_kernel", [&] {
       aes_helper<scalar_t, uint64_t, 1>(iter, key,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#55 fix key_tensor to use all 4 random bytes**

