### PR TITLE
Fix conda and pip installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,11 +64,11 @@ Anaconda:
 
 pip:
 
-| OS      | CUDA                                          |                                                                               |
-|---------|-----------------------------------------------|-------------------------------------------------------------------------------|
-| Linux   | 9.2<br/><br/>10.1<br/><br/>10.2<br/><br/>None | pip install torchcsprng ?<br/><br/>pip install torchcsprng ?<br/><br/>pip install torchcsprng ?<br/><br/>pip install torchcsprng |
-| macOS   | None                                          | pip install torchcsprng                                                       |
-| Windows | None                                          | pip install torchcsprng -f https://download.pytorch.org/whl/torch_stable.html |
+| OS      | CUDA                                          |                                                                                     |
+|---------|-----------------------------------------------|-------------------------------------------------------------------------------------|
+| Linux   | 9.2<br/><br/>10.1<br/><br/>10.2<br/><br/>None | pip install torchcsprng==0.1.1+cu92 torch==1.6.0+cu92 -f https://download.pytorch.org/whl/torch_stable.html <br/><br/>pip install torchcsprng==0.1.1+cu101 torch==1.6.0+cu101 -f https://download.pytorch.org/whl/torch_stable.html <br/><br/>pip install torchcsprng torch<br/><br/>pip install torchcsprng==0.1.1+cpu torch==1.6.0+cpu -f https://download.pytorch.org/whl/torch_stable.html |
+| macOS   | None                                          | pip install torchcsprng torch                                                       |
+| Windows | None                                          | pip install torchcsprng torch -f https://download.pytorch.org/whl/torch_stable.html |
 
 ### Nightly builds:
 

--- a/README.md
+++ b/README.md
@@ -56,24 +56,29 @@ CSPRNG works with Python 3.6/3.7/3.8 on the following operating systems and can 
 
 Anaconda:
 
-```console
-conda install torchcsprng -c pytorch
-```
+| OS      | CUDA                                          |                                              |
+|---------|-----------------------------------------------|----------------------------------------------|
+| Linux   | 9.2<br/><br/>10.1<br/><br/>10.2<br/><br/>None | conda install torchcsprng cudatoolkit=9.2 -c pytorch<br/><br/>conda install torchcsprng cudatoolkit=10.1 -c pytorch<br/><br/>conda install torchcsprng cudatoolkit=10.2 -c pytorch<br/><br/>conda install torchcsprng cpuonly -c pytorch |
+| macOS   | None                                          | conda install torchcsprng cpuonly -c pytorch |
+| Windows | None                                          | conda install torchcsprng cpuonly -c pytorch |
 
 pip:
 
-```console
-pip install torchcsprng
-```
+| OS      | CUDA                                          |                                                                               |
+|---------|-----------------------------------------------|-------------------------------------------------------------------------------|
+| Linux   | 9.2<br/><br/>10.1<br/><br/>10.2<br/><br/>None | pip install torchcsprng ?<br/><br/>pip install torchcsprng ?<br/><br/>pip install torchcsprng ?<br/><br/>pip install torchcsprng |
+| macOS   | None                                          | pip install torchcsprng                                                       |
+| Windows | None                                          | pip install torchcsprng -f https://download.pytorch.org/whl/torch_stable.html |
 
 Nightly builds:
 
 Anaconda:
 
-| OS                     | CUDA                                          |                                                       |
-|------------------------|-----------------------------------------------|-------------------------------------------------------|
-| Linux                  | 9.2<br/><br/>10.1<br/><br/>10.2<br/><br/>None | conda install torchcsprng -c pytorch-nightly         |
-| macOS<br/><br/>Windows | None<br><br>None                              | conda install torchcsprng -c pytorch-nightly<br/><br/>conda install torchcsprng cpuonly -c pytorch-nightly         |
+| OS      | CUDA                                          |                                                      |
+|---------|-----------------------------------------------|------------------------------------------------------|
+| Linux   | 9.2<br/><br/>10.1<br/><br/>10.2<br/><br/>None | conda install torchcsprng cudatoolkit=9.2 -c pytorch-nightly<br/><br/>conda install torchcsprng cudatoolkit=10.1 -c pytorch-nightly<br/><br/>conda install torchcsprng cudatoolkit=10.2 -c pytorch-nightly<br/><br/>conda install torchcsprng cpuonly -c pytorch-nightly |
+| macOS   | None                                          | conda install torchcsprng cpuonly -c pytorch-nightly |
+| Windows | None                                          | conda install torchcsprng cpuonly -c pytorch-nightly |
 
 pip:
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ pip:
 | macOS   | None                                          | pip install torchcsprng                                                       |
 | Windows | None                                          | pip install torchcsprng -f https://download.pytorch.org/whl/torch_stable.html |
 
-Nightly builds:
+### Nightly builds:
 
 Anaconda:
 

--- a/README.md
+++ b/README.md
@@ -82,10 +82,11 @@ Anaconda:
 
 pip:
 
-| OS                     | CUDA                                          |                                                                                                    |
-|------------------------|-----------------------------------------------|----------------------------------------------------------------------------------------------------|
-| Linux                  | 9.2<br/><br/>10.1<br/><br/>10.2<br/><br/>None | pip install --pre torchcsprng -f https://download.pytorch.org/whl/nightly/cu92/torch_nightly.html <br/><br/> pip install --pre torchcsprng -f https://download.pytorch.org/whl/nightly/cu101/torch_nightly.html <br/><br/> pip install --pre torchcsprng -f https://download.pytorch.org/whl/nightly/cu102/torch_nightly.html <br/><br/> pip install --pre torchcsprng -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html |
-| macOS<br/><br/>Windows | None<br><br>None                              | pip install --pre torchcsprng -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html   |
+| OS      | CUDA                                          |                                                                                                    |
+|---------|-----------------------------------------------|----------------------------------------------------------------------------------------------------|
+| Linux   | 9.2<br/><br/>10.1<br/><br/>10.2<br/><br/>None | pip install --pre torchcsprng -f https://download.pytorch.org/whl/nightly/cu92/torch_nightly.html <br/><br/> pip install --pre torchcsprng -f https://download.pytorch.org/whl/nightly/cu101/torch_nightly.html <br/><br/> pip install --pre torchcsprng -f https://download.pytorch.org/whl/nightly/cu102/torch_nightly.html <br/><br/> pip install --pre torchcsprng -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html |
+| macOS   | None                                          | pip install --pre torchcsprng -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html   |
+| Windows | None                                          | pip install --pre torchcsprng -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html   |
 
 ### From Source
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#66 Fix conda and pip installation instructions**

