### PR TITLE
.circleci: Bump xcode workers to 9.4.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -157,7 +157,7 @@ jobs:
   binary_macos_wheel:
     <<: *binary_common
     macos:
-      xcode: "9.0"
+      xcode: "9.4.1"
     steps:
       - checkout_merge
       - run:
@@ -179,7 +179,7 @@ jobs:
   binary_macos_conda:
     <<: *binary_common
     macos:
-      xcode: "9.0"
+      xcode: "9.4.1"
     steps:
       - checkout_merge
       - run:


### PR DESCRIPTION
Signed-off-by: Eli Uriegas <eliuriegas@fb.com>