### PR TITLE
.circleci: Bump pytorch -> 1.7.0, version -> 0.1.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,11 +48,11 @@ binary_common: &binary_common
     build_version:
       description: "version number of release binary; by default, build a nightly"
       type: string
-      default: "0.1.0"
+      default: "0.1.3"
     pytorch_version:
       description: "PyTorch version to build against; by default, use a nightly"
       type: string
-      default: "1.6.0"
+      default: "1.7.0"
     # Don't edit these
     python_version:
       description: "Python version to build against (e.g., 3.7)"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,12 +35,7 @@ commands:
       - run:
           name: adding UPLOAD_CHANNEL to BASH_ENV
           command: |
-            our_upload_channel=nightly
-            # On tags upload to test instead
-            if [[ -n "${CIRCLE_TAG}" ]]; then
-              our_upload_channel=test
-            fi
-            echo "export UPLOAD_CHANNEL=${our_upload_channel}" >> ${BASH_ENV}
+            echo "export UPLOAD_CHANNEL=test" >> ${BASH_ENV}
 
 binary_common: &binary_common
   parameters:

--- a/packaging/pkg_helpers.bash
+++ b/packaging/pkg_helpers.bash
@@ -216,10 +216,10 @@ setup_pip_pytorch_version() {
       export PYTORCH_VERSION="$(pip show torch | grep ^Version: | sed 's/Version:  *//')"
     fi
   else
+    UPLOAD_CHANNEL=${UPLOAD_CHANNEL:-nightly}
     pip_install "torch==$PYTORCH_VERSION$PYTORCH_VERSION_SUFFIX" \
-      -f https://download.pytorch.org/whl/torch_stable.html \
-      -f https://download.pytorch.org/whl/test/torch_test.html \
-      -f https://download.pytorch.org/whl/nightly/torch_nightly.html
+      -f "https://download.pytorch.org/whl/${CU_VERSION}/torch_stable.html" \
+      -f "https://download.pytorch.org/whl/${UPLOAD_CHANNEL}/${CU_VERSION}/torch_${UPLOAD_CHANNEL}.html"
   fi
 }
 
@@ -244,7 +244,8 @@ setup_conda_pytorch_constraint() {
       exit 1
     fi
   else
-    export CONDA_CHANNEL_FLAGS="-c pytorch -c pytorch-nightly -c pytorch-test"
+    UPLOAD_CHANNEL=${UPLOAD_CHANNEL:-nightly}
+    export CONDA_CHANNEL_FLAGS="-c pytorch -c pytorch-${UPLOAD_CHANNEL}"
   fi
   if [[ "$CU_VERSION" == cpu ]]; then
     export CONDA_PYTORCH_BUILD_CONSTRAINT="- pytorch==$PYTORCH_VERSION${PYTORCH_VERSION_SUFFIX}"


### PR DESCRIPTION
To release compatible binaries for PyTorch 1.7

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>