### PR TITLE
test_encrypt_decrypt against pycrypto

### DIFF
--- a/.circleci/unittest/linux/scripts/environment.yml
+++ b/.circleci/unittest/linux/scripts/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - codecov
   - pip
   - ca-certificates
+  - pycrypto
   - pip:
       - future
       - scipy
-      - pycrypto

--- a/.circleci/unittest/linux/scripts/environment.yml
+++ b/.circleci/unittest/linux/scripts/environment.yml
@@ -11,3 +11,4 @@ dependencies:
   - pip:
       - future
       - scipy
+      - pycrypto

--- a/.circleci/unittest/windows/scripts/environment.yml
+++ b/.circleci/unittest/windows/scripts/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - codecov
   - pip
   - ca-certificates
+  - pycrypto
   - pip:
       - future
       - scipy
-      - pycrypto

--- a/.circleci/unittest/windows/scripts/environment.yml
+++ b/.circleci/unittest/windows/scripts/environment.yml
@@ -11,3 +11,4 @@ dependencies:
   - pip:
       - future
       - scipy
+      - pycrypto

--- a/packaging/torchcsprng/meta.yaml
+++ b/packaging/torchcsprng/meta.yaml
@@ -45,6 +45,7 @@ build:
 #  requires:
 #    - pytest
 #    - scipy
+#    - pycrypto
 #  commands:
 #    pytest . --verbose
 

--- a/packaging/wheel/osx_wheel.sh
+++ b/packaging/wheel/osx_wheel.sh
@@ -41,7 +41,7 @@ do
     echo "Building against ${TORCHAUDIO_PYTORCH_DEPENDENCY_VERSION}"
 
     # install torchcsprng dependencies
-    pip install ninja scipy pytest
+    pip install ninja scipy pytest pycrypto
 
     python setup.py clean
     python setup.py bdist_wheel

--- a/packaging/windows/build_csprng.bat
+++ b/packaging/windows/build_csprng.bat
@@ -64,7 +64,7 @@ FOR %%v IN (%DESIRED_PYTHON%) DO (
     set PYTHON_VERSION_STR=%%v
     set PYTHON_VERSION_STR=!PYTHON_VERSION_STR:.=!
     conda remove -n py!PYTHON_VERSION_STR! --all -y || rmdir %CONDA_HOME%\envs\py!PYTHON_VERSION_STR! /s
-    conda create -n py!PYTHON_VERSION_STR! -y -q -c defaults -c conda-forge numpy>=1.11 mkl>=2018 python=%%v ca-certificates scipy
+    conda create -n py!PYTHON_VERSION_STR! -y -q -c defaults -c conda-forge numpy>=1.11 mkl>=2018 python=%%v ca-certificates scipy pycrypto
 )
 
 :: Uncomment for stable releases

--- a/test/test_csprng.py
+++ b/test/test_csprng.py
@@ -304,15 +304,15 @@ class TestCSPRNG(unittest.TestCase):
         def measure(size):
             t = torch.empty(size, dtype=torch.float32, device='cpu')
             start = time.time()
-            for i in range(10):
+            for i in range(20):
                 t.normal_(generator=urandom_gen)
             finish = time.time()
             return finish - start
 
-        time_for_10K = measure(10000)
+        time_for_1K = measure(1000)
         time_for_1M = measure(1000000)
         # Pessimistic check that parallel execution gives >= 1.5 performance boost
-        self.assertTrue(time_for_1M/time_for_10K < 100 / 1.5)
+        self.assertTrue(time_for_1M/time_for_1K < 1000 / 1.5)
 
     @unittest.skipIf(IS_SANDCASTLE or IS_FBCODE, "Does not work on Sandcastle")
     def test_version(self):

--- a/test/test_csprng.py
+++ b/test/test_csprng.py
@@ -395,7 +395,7 @@ class TestCSPRNG(unittest.TestCase):
 
                                     aes = create_aes(mode, key_np)
 
-                                    encrypted_expected = np.frombuffer(aes.encrypt(pad(initial_np.tobytes(), 16)), dtype=np.int8)
+                                    encrypted_expected = np.frombuffer(aes.encrypt(pad(initial_np.tobytes(), block_size_bytes)), dtype=np.int8)
                                     self.assertTrue(np.array_equal(encrypted_np, encrypted_expected))
 
                                     csprng.decrypt(encrypted, decrypted, key, "aes128", mode)
@@ -403,7 +403,7 @@ class TestCSPRNG(unittest.TestCase):
 
                                     aes = create_aes(mode, key_np)
 
-                                    decrypted_expected = np.frombuffer(aes.decrypt(pad(encrypted_np.tobytes(), 16)), dtype=np.int8)
+                                    decrypted_expected = np.frombuffer(aes.decrypt(pad(encrypted_np.tobytes(), block_size_bytes)), dtype=np.int8)
                                     self.assertTrue(np.array_equal(decrypted_np, decrypted_expected))
 
                                     padding_size_bytes = initial_size * sizeof(initial_dtype) - decrypted_size * sizeof(decrypted_dtype)

--- a/test/test_csprng.py
+++ b/test/test_csprng.py
@@ -394,8 +394,21 @@ class TestCSPRNG(unittest.TestCase):
                                         aes = None
 
                                     encrypted_expected = np.frombuffer(aes.encrypt(pad(initial_np.tobytes(), 16)), dtype=np.int8)
-                                    print(encrypted_np)
-                                    print(encrypted_expected)
+
+                                    print("device =", device)
+                                    print("key_dtype =", key_dtype)
+                                    print("mode =", mode)
+
+                                    print("initial_dtype =", initial_dtype)
+                                    print("initial_size =", initial_size)
+                                    print("initial_np =", initial_np)
+
+                                    print("encrypted_dtype =", encrypted_dtype)
+                                    print("encrypted_size =", encrypted_size)
+                                    print("encrypted_np =", encrypted_np)
+
+                                    print("encrypted_expected =", encrypted_expected)
+
                                     self.assertTrue(np.array_equal(encrypted_np, encrypted_expected))
 
                                     csprng.decrypt(encrypted, decrypted, key, "aes128", mode)

--- a/test/test_csprng.py
+++ b/test/test_csprng.py
@@ -394,6 +394,8 @@ class TestCSPRNG(unittest.TestCase):
                                         aes = None
 
                                     encrypted_expected = np.frombuffer(aes.encrypt(pad(initial_np.tobytes(), 16)), dtype=np.int8)
+                                    print(encrypted_np)
+                                    print(encrypted_expected)
                                     self.assertTrue(np.array_equal(encrypted_np, encrypted_expected))
 
                                     csprng.decrypt(encrypted, decrypted, key, "aes128", mode)

--- a/test/test_csprng.py
+++ b/test/test_csprng.py
@@ -309,10 +309,10 @@ class TestCSPRNG(unittest.TestCase):
             finish = time.time()
             return finish - start
 
-        time_for_1K = measure(1000)
+        time_for_10K = measure(10000)
         time_for_1M = measure(1000000)
         # Pessimistic check that parallel execution gives >= 1.5 performance boost
-        self.assertTrue(time_for_1M/time_for_1K < 1000 / 1.5)
+        self.assertTrue(time_for_1M/time_for_10K < 100 / 1.5)
 
     @unittest.skipIf(IS_SANDCASTLE or IS_FBCODE, "Does not work on Sandcastle")
     def test_version(self):


### PR DESCRIPTION
This PR checks if `torchcsprng.encrypt` and `torchcsprng.decrypt` results are identical to `Crypto.Ciphe.AES.encrypt` and `Crypto.Ciphe.AES.decrypt` in ECB and CTR modes

Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#92 test_encrypt_decrypt against pycrypto**

Differential Revision: [D25405747](https://our.internmc.facebook.com/intern/diff/D25405747)