### PR TITLE
Add __version__ to __init__.py

### DIFF
--- a/torchcsprng/__init__.py
+++ b/torchcsprng/__init__.py
@@ -7,3 +7,9 @@
 import torch
 
 from torchcsprng._C import *
+
+
+try:
+    from .version import __version__, git_version  # noqa: F401
+except ImportError:
+    pass


### PR DESCRIPTION
Fix `AttributeError: module 'torchcsprng' has no attribute '__version__'` when calling `torchcsprng.__version__`.