### PR TITLE
Migrate off legacy CircleCI gpu executors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -291,7 +291,7 @@ jobs:
     <<: *binary_common
     machine:
       image: ubuntu-1604-cuda-10.1:201909-23
-    resource_class: gpu.small
+    resource_class: gpu.nvidia.small.multi
     environment:
       image_name: "pytorch/manylinux-cuda101"
       PYTHON_VERSION: << parameters.python_version >>


### PR DESCRIPTION
Summary: Changing legacy GPU resource classes to `gpu.nvidia.small.multi`

Differential Revision: D33749817

