### PR TITLE
Remove strict dependency on a specific PyTorch version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,12 +51,9 @@ write_version_file()
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
-pytorch_dep = "torch"
-if os.getenv("PYTORCH_VERSION"):
-    pytorch_dep += "==" + os.getenv("PYTORCH_VERSION")
 
 requirements = [
-    pytorch_dep,
+    "torch",
 ]
 
 


### PR DESCRIPTION
When building artifacts, PyTorch version is set strictly (`pytorch=xxx`) to the current version used in the build image. This forces reinstall of pytorch when installing csprng, although there is no actual reasons to use a specific version.

Opacus is affected and blocked because of this problem: https://github.com/pytorch/opacus/issues/351

This PR changes deps in setup.py to just `pytorch` (without specifying bounds).